### PR TITLE
Support generic type for HalResource property.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ export interface HalLink {
 /**
  * A HAL document
  */
-export interface HalResource {
+export interface HalResource<T extends Record<string, any>> extends T {
 
   /**
    * List of links, indexed by their relationship.
@@ -49,7 +49,6 @@ export interface HalResource {
     self: HalLink,
     [rel: string]: HalLink | HalLink[];
   };
-  [property: string]: any;
 
   /**
    * Embedded resources

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ export interface HalLink {
 /**
  * A HAL document
  */
-export interface HalResource<T extends Record<string, any>> extends T {
+export interface HalResource<T extends Record<string, any> = Record<string, any>> extends T {
 
   /**
    * List of links, indexed by their relationship.


### PR DESCRIPTION
## Description
When you get the HalResource, can't guess the property.

## Improvements
I use record with generic type. 

## Result
```
type Property = {something: string}
HalResource<Property> resource

// can access properties and get its type.
const st:string = resource.something
```