### PR TITLE
Make _links and self optional

### DIFF
--- a/src/hal.ts
+++ b/src/hal.ts
@@ -48,8 +48,8 @@ export type HalResource<T extends Record<string, any> = Record<string, any>> = {
    *
    * Each value is either a Link, or an array of Links
    */
-  _links: {
-    self: HalLink,
+  _links?: {
+    self?: HalLink,
     [rel: string]: HalLink | HalLink[];
   };
 

--- a/src/hal.ts
+++ b/src/hal.ts
@@ -50,14 +50,14 @@ export type HalResource<T extends Record<string, any> = Record<string, any>> = {
    */
   _links?: {
     self?: HalLink,
-    [rel: string]: HalLink | HalLink[];
+    [rel: string]: HalLink | HalLink[] | undefined;
   };
 
   /**
    * Embedded resources
    */
   _embedded?: {
-    [rel: string]: HalResource | HalResource[];
+    [rel: string]: HalResource | HalResource[] | undefined;
   };
 
   /**


### PR DESCRIPTION
A HAL+JSON document that you retrieve from an API and deserialize in your client should always have a "self" link within the "_links" object. However, this does not apply to every HAL+JSON document. For example, a HAL+JSON document that you send to the API with a POST request (to create some new API resource) would typically not have such a "self" link. This is because the API would usually generate the "self" link (though it may sometimes also accept and use a client-generated "self" link). This is why the TypeScript type for HAL+JSON documents should have the "_links" and "self" fields optional.