### PR TITLE
Fix BC breaking types.

### DIFF
--- a/src/hal.ts
+++ b/src/hal.ts
@@ -49,15 +49,15 @@ export type HalResource<T extends Record<string, any> = Record<string, any>> = {
    * Each value is either a Link, or an array of Links
    */
   _links?: {
-    self?: HalLink;
-    [rel: string]: HalLink | HalLink[] | undefined;
+    self: HalLink;
+    [rel: string]: HalLink | HalLink[];
   };
 
   /**
    * Embedded resources
    */
   _embedded?: {
-    [rel: string]: HalResource | HalResource[] | undefined;
+    [rel: string]: HalResource | HalResource[];
   };
 
   /**


### PR DESCRIPTION
PR #45 introduced some changes that were BC-breaking, allowing parts of the HAL document to be `undefined`.

I'm reverting this, because 1.7.5 is causing new bugs, but also `undefined` doesn't even exists in JSON so it doesn't make a ton of sense to me.